### PR TITLE
fixes issue with yumrepo baseuri error in recent puppet releases

### DIFF
--- a/manifests/repos/redhat.pp
+++ b/manifests/repos/redhat.pp
@@ -5,7 +5,7 @@ class omd::repos::redhat {
     descr => "Consol* Labs Repository",
     enabled => 1,
     gpgcheck => 1,
-    gpgkey => 'gpgkey=http://labs.consol.de/repo/stable/RPM-GPG-KEY',
+    gpgkey => 'http://labs.consol.de/repo/stable/RPM-GPG-KEY',
   }
   
   #test releases
@@ -14,6 +14,6 @@ class omd::repos::redhat {
     descr => "Consol* Labs TESTING Repository",
     enabled => 1,
     gpgcheck => 1,
-    gpgkey => 'gpgkey=https://labs.consol.de/repo/testing/RPM-GPG-KEY',
+    gpgkey => 'https://labs.consol.de/repo/testing/RPM-GPG-KEY',
   }  
 }


### PR DESCRIPTION
The commited changes fixes issues with `yumrepo`:

```
Error: Failed to apply catalog: Parameter gpgkey failed on Yumrepo[omd]: Validate method failed for class gpgkey: bad URI(is not URI?): gpgkey=http://labs.consol.de/repo/stable/RPM-GPG-KEY at /etc/puppet/modules/common/omd/manifests/repos/redhat.pp:9
Wrapped exception:
Validate method failed for class gpgkey: bad URI(is not URI?): gpgkey=http://labs.consol.de/repo/stable/RPM-GPG-KEY
/usr/lib/ruby/site_ruby/1.8/puppet/agent.rb:87:in `exit': no implicit conversion from nil to integer (TypeError)
    from /usr/lib/ruby/site_ruby/1.8/puppet/agent.rb:87:in `run_in_fork'
    from /usr/lib/ruby/site_ruby/1.8/puppet/agent.rb:84:in `fork'
    from /usr/lib/ruby/site_ruby/1.8/puppet/agent.rb:84:in `run_in_fork'
    from /usr/lib/ruby/site_ruby/1.8/puppet/agent.rb:43:in `run'
    from /usr/lib/ruby/site_ruby/1.8/puppet/application.rb:179:in `call'
    from /usr/lib/ruby/site_ruby/1.8/puppet/application.rb:179:in `controlled_run'
    from /usr/lib/ruby/site_ruby/1.8/puppet/agent.rb:41:in `run'
    from /usr/lib/ruby/site_ruby/1.8/puppet/daemon.rb:163:in `run_event_loop'
    from /usr/lib/ruby/site_ruby/1.8/puppet/scheduler/job.rb:49:in `call'
    from /usr/lib/ruby/site_ruby/1.8/puppet/scheduler/job.rb:49:in `run'
    from /usr/lib/ruby/site_ruby/1.8/puppet/scheduler/scheduler.rb:39:in `run_ready'
    from /usr/lib/ruby/site_ruby/1.8/puppet/scheduler/scheduler.rb:34:in `each'
    from /usr/lib/ruby/site_ruby/1.8/puppet/scheduler/scheduler.rb:34:in `run_ready'
    from /usr/lib/ruby/site_ruby/1.8/puppet/scheduler/scheduler.rb:11:in `run_loop'
    from /usr/lib/ruby/site_ruby/1.8/puppet/daemon.rb:179:in `run_event_loop'
    from /usr/lib/ruby/site_ruby/1.8/puppet/daemon.rb:142:in `start'
    from /usr/lib/ruby/site_ruby/1.8/puppet/application/agent.rb:377:in `main'
    from /usr/lib/ruby/site_ruby/1.8/puppet/application/agent.rb:323:in `run_command'
    from /usr/lib/ruby/site_ruby/1.8/puppet/application.rb:371:in `run'
    from /usr/lib/ruby/site_ruby/1.8/puppet/application.rb:477:in `plugin_hook'
    from /usr/lib/ruby/site_ruby/1.8/puppet/application.rb:371:in `run'
    from /usr/lib/ruby/site_ruby/1.8/puppet/util.rb:479:in `exit_on_fail'
    from /usr/lib/ruby/site_ruby/1.8/puppet/application.rb:371:in `run'
    from /usr/lib/ruby/site_ruby/1.8/puppet/util/command_line.rb:137:in `run'
    from /usr/lib/ruby/site_ruby/1.8/puppet/util/command_line.rb:91:in `execute'
    from /usr/bin/puppet:8

```
