### PR TITLE
lsbmajdistrelease deprecated for operatingsystemmajrelease

### DIFF
--- a/manifests/repos/redhat.pp
+++ b/manifests/repos/redhat.pp
@@ -1,7 +1,7 @@
 class omd::repos::redhat {
   #stable releases
   yumrepo { "omd":
-    baseurl => "https://labs.consol.de/repo/stable/rhel${::lsbmajdistrelease}/${::architecture}",
+    baseurl => "https://labs.consol.de/repo/stable/rhel${::operatingsystemmajrelease}/${::architecture}",
     descr => "Consol* Labs Repository",
     enabled => 1,
     gpgcheck => 1,
@@ -10,7 +10,7 @@ class omd::repos::redhat {
   
   #test releases
   yumrepo { "omd-testing":
-    baseurl => "https://labs.consol.de/repo/testing/rhel${::lsbmajdistrelease}/${::architecture}",
+    baseurl => "https://labs.consol.de/repo/testing/rhel${::operatingsystemmajrelease}/${::architecture}",
     descr => "Consol* Labs TESTING Repository",
     enabled => 1,
     gpgcheck => 1,


### PR DESCRIPTION
Using `lsbmajdistrelease` with newer facter versions will cause broken yum repositories since this variable is no longer populated correctly. with the use of `operatingsystemmajrelease` this works flawlessly.

see: 
https://projects.puppetlabs.com/issues/15159
https://github.com/ghoneycutt/puppet-module-inittab/issues/57

errors encountered:

```
[...]

Debug: Executing '/usr/bin/python /usr/lib/ruby/site_ruby/1.8/puppet/provider/package/yumhelper.py'
Error: Could not get latest version: Execution of '/usr/bin/python /usr/lib/ruby/site_ruby/1.8/puppet/provider/package/yumhelper.py' returned 1: Loaded plugins: fastestmirror
Loading mirror speeds from cached hostfile
 * epel: mirror.vutbr.cz
Traceback (most recent call last):
  File "/usr/lib/ruby/site_ruby/1.8/puppet/provider/package/yumhelper.py", line 145, in <module>
    ypl = pkg_lists(my)
  File "/usr/lib/ruby/site_ruby/1.8/puppet/provider/package/yumhelper.py", line 58, in pkg_lists
    my.doTsSetup()
  File "/usr/lib/python2.6/site-packages/yum/depsolve.py", line 84, in doTsSetup
    return self._getTs()
  File "/usr/lib/python2.6/site-packages/yum/depsolve.py", line 99, in _getTs
    self._getTsInfo(remove_only)
  File "/usr/lib/python2.6/site-packages/yum/depsolve.py", line 110, in _getTsInfo
    pkgSack = self.pkgSack
  File "/usr/lib/python2.6/site-packages/yum/__init__.py", line 887, in <lambda>
    pkgSack = property(fget=lambda self: self._getSacks(),
  File "/usr/lib/python2.6/site-packages/yum/__init__.py", line 669, in _getSacks
    self.repos.populateSack(which=repos)
  File "/usr/lib/python2.6/site-packages/yum/repos.py", line 308, in populateSack
    sack.populate(repo, mdtype, callback, cacheonly)
  File "/usr/lib/python2.6/site-packages/yum/yumRepo.py", line 165, in populate
    if self._check_db_version(repo, mydbtype):
  File "/usr/lib/python2.6/site-packages/yum/yumRepo.py", line 223, in _check_db_version
    return repo._check_db_version(mdtype)
  File "/usr/lib/python2.6/site-packages/yum/yumRepo.py", line 1256, in _check_db_version
    repoXML = self.repoXML
  File "/usr/lib/python2.6/site-packages/yum/yumRepo.py", line 1455, in <lambda>
    repoXML = property(fget=lambda self: self._getRepoXML(),
  File "/usr/lib/python2.6/site-packages/yum/yumRepo.py", line 1451, in _getRepoXML
    raise Errors.RepoError, msg
yum.Errors.RepoError: Cannot retrieve repository metadata (repomd.xml) for repository: omd. Please verify its path and try again
Error: /Stage[main]/Omd/Package[omd]/ensure: change from rh61-31 to latest failed: Could not get latest version: Execution of '/usr/bin/python /usr/lib/ruby/site_ruby/1.8/puppet/provider/package/yumhelper.py' returned 1: Loaded plugins: fastestmirror
Loading mirror speeds from cached hostfile
 * epel: mirror.vutbr.cz
Traceback (most recent call last):
  File "/usr/lib/ruby/site_ruby/1.8/puppet/provider/package/yumhelper.py", line 145, in <module>
    ypl = pkg_lists(my)
  File "/usr/lib/ruby/site_ruby/1.8/puppet/provider/package/yumhelper.py", line 58, in pkg_lists
    my.doTsSetup()
  File "/usr/lib/python2.6/site-packages/yum/depsolve.py", line 84, in doTsSetup
    return self._getTs()
  File "/usr/lib/python2.6/site-packages/yum/depsolve.py", line 99, in _getTs
    self._getTsInfo(remove_only)
  File "/usr/lib/python2.6/site-packages/yum/depsolve.py", line 110, in _getTsInfo
    pkgSack = self.pkgSack
  File "/usr/lib/python2.6/site-packages/yum/__init__.py", line 887, in <lambda>
    pkgSack = property(fget=lambda self: self._getSacks(),
  File "/usr/lib/python2.6/site-packages/yum/__init__.py", line 669, in _getSacks
    self.repos.populateSack(which=repos)
  File "/usr/lib/python2.6/site-packages/yum/repos.py", line 308, in populateSack
    sack.populate(repo, mdtype, callback, cacheonly)
  File "/usr/lib/python2.6/site-packages/yum/yumRepo.py", line 165, in populate
    if self._check_db_version(repo, mydbtype):
  File "/usr/lib/python2.6/site-packages/yum/yumRepo.py", line 223, in _check_db_version
    return repo._check_db_version(mdtype)
  File "/usr/lib/python2.6/site-packages/yum/yumRepo.py", line 1256, in _check_db_version
    repoXML = self.repoXML
  File "/usr/lib/python2.6/site-packages/yum/yumRepo.py", line 1455, in <lambda>
    repoXML = property(fget=lambda self: self._getRepoXML(),
  File "/usr/lib/python2.6/site-packages/yum/yumRepo.py", line 1451, in _getRepoXML
    raise Errors.RepoError, msg
yum.Errors.RepoError: Cannot retrieve repository metadata (repomd.xml) for repository: omd. Please verify its path and try again
Notice: /Stage[main]/Omd/Service[omd]: Dependency Package[omd] has failures: true
Warning: /Stage[main]/Omd/Service[omd]: Skipping because of failed dependencies
Debug: Exec[import-EPEL-6](provider=posix): Executing check 'rpm -q gpg-pubkey-$(echo $(gpg --throw-keyids < /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6) | cut --characters=11-18 | tr '[A-Z]' '[a-z]')'
Debug: Executing 'rpm -q gpg-pubkey-$(echo $(gpg --throw-keyids < /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6) | cut --characters=11-18 | tr '[A-Z]' '[a-z]')'
Debug: /Stage[main]/Epel/Epel::Rpm_gpg_key[EPEL-6]/Exec[import-EPEL-6]/unless: gpg-pubkey-0608b895-4bd22942
Debug: Prefetching inifile resources for yumrepo
Debug: Failed to load library 'msgpack' for feature 'msgpack'
Debug: Puppet::Network::Format[msgpack]: feature msgpack is missing
Debug: file_metadata supports formats: pson yaml b64_zlib_yaml raw
Debug: Executing '/sbin/service autofs status'
Debug: Executing '/sbin/chkconfig autofs'
Debug: Failed to load library 'msgpack' for feature 'msgpack'
Debug: Puppet::Network::Format[msgpack]: feature msgpack is missing
Debug: file_metadata supports formats: pson yaml b64_zlib_yaml raw
Notice: /Stage[main]/Omd::Repos::Redhat/Yumrepo[omd-testing]/baseurl: baseurl changed 'https://labs.consol.de/repo/testing/rhel/x86_64' to 'https://labs.consol.de/repo/testing/rhel6/x86_64'
Debug: /Stage[main]/Omd::Repos::Redhat/Yumrepo[omd-testing]: The container Class[Omd::Repos::Redhat] will propagate my refresh event
Debug: Executing '/usr/bin/python /usr/lib/ruby/site_ruby/1.8/puppet/provider/package/yumhelper.py'
Error: Could not get latest version: Execution of '/usr/bin/python /usr/lib/ruby/site_ruby/1.8/puppet/provider/package/yumhelper.py' returned 1: Loaded plugins: fastestmirror
Loading mirror speeds from cached hostfile
 * epel: mirror.vutbr.cz
Traceback (most recent call last):
  File "/usr/lib/ruby/site_ruby/1.8/puppet/provider/package/yumhelper.py", line 145, in <module>
    ypl = pkg_lists(my)
  File "/usr/lib/ruby/site_ruby/1.8/puppet/provider/package/yumhelper.py", line 58, in pkg_lists
    my.doTsSetup()
  File "/usr/lib/python2.6/site-packages/yum/depsolve.py", line 84, in doTsSetup
    return self._getTs()
  File "/usr/lib/python2.6/site-packages/yum/depsolve.py", line 99, in _getTs
    self._getTsInfo(remove_only)
  File "/usr/lib/python2.6/site-packages/yum/depsolve.py", line 110, in _getTsInfo
    pkgSack = self.pkgSack
  File "/usr/lib/python2.6/site-packages/yum/__init__.py", line 887, in <lambda>
    pkgSack = property(fget=lambda self: self._getSacks(),
  File "/usr/lib/python2.6/site-packages/yum/__init__.py", line 669, in _getSacks
    self.repos.populateSack(which=repos)
  File "/usr/lib/python2.6/site-packages/yum/repos.py", line 308, in populateSack
    sack.populate(repo, mdtype, callback, cacheonly)
  File "/usr/lib/python2.6/site-packages/yum/yumRepo.py", line 165, in populate
    if self._check_db_version(repo, mydbtype):
  File "/usr/lib/python2.6/site-packages/yum/yumRepo.py", line 223, in _check_db_version
    return repo._check_db_version(mdtype)
  File "/usr/lib/python2.6/site-packages/yum/yumRepo.py", line 1256, in _check_db_version
    repoXML = self.repoXML
  File "/usr/lib/python2.6/site-packages/yum/yumRepo.py", line 1455, in <lambda>
    repoXML = property(fget=lambda self: self._getRepoXML(),
  File "/usr/lib/python2.6/site-packages/yum/yumRepo.py", line 1451, in _getRepoXML
    raise Errors.RepoError, msg
yum.Errors.RepoError: Cannot retrieve repository metadata (repomd.xml) for repository: omd. Please verify its path and try again
Error: /Stage[main]/Rsyslog::Install/Package[rsyslog-relp]/ensure: change from 5.8.10-8.el6 to latest failed: Could not get latest version: Execution of '/usr/bin/python /usr/lib/ruby/site_ruby/1.8/puppet/provider/package/yumhelper.py' returned 1: Loaded plugins: fastestmirror
Loading mirror speeds from cached hostfile
 * epel: mirror.vutbr.cz
Traceback (most recent call last):
  File "/usr/lib/ruby/site_ruby/1.8/puppet/provider/package/yumhelper.py", line 145, in <module>
    ypl = pkg_lists(my)
  File "/usr/lib/ruby/site_ruby/1.8/puppet/provider/package/yumhelper.py", line 58, in pkg_lists
    my.doTsSetup()
  File "/usr/lib/python2.6/site-packages/yum/depsolve.py", line 84, in doTsSetup
    return self._getTs()
  File "/usr/lib/python2.6/site-packages/yum/depsolve.py", line 99, in _getTs
    self._getTsInfo(remove_only)
  File "/usr/lib/python2.6/site-packages/yum/depsolve.py", line 110, in _getTsInfo
    pkgSack = self.pkgSack
  File "/usr/lib/python2.6/site-packages/yum/__init__.py", line 887, in <lambda>
    pkgSack = property(fget=lambda self: self._getSacks(),
  File "/usr/lib/python2.6/site-packages/yum/__init__.py", line 669, in _getSacks
    self.repos.populateSack(which=repos)
  File "/usr/lib/python2.6/site-packages/yum/repos.py", line 308, in populateSack
    sack.populate(repo, mdtype, callback, cacheonly)
  File "/usr/lib/python2.6/site-packages/yum/yumRepo.py", line 165, in populate
    if self._check_db_version(repo, mydbtype):
  File "/usr/lib/python2.6/site-packages/yum/yumRepo.py", line 223, in _check_db_version
    return repo._check_db_version(mdtype)
  File "/usr/lib/python2.6/site-packages/yum/yumRepo.py", line 1256, in _check_db_version
    repoXML = self.repoXML
  File "/usr/lib/python2.6/site-packages/yum/yumRepo.py", line 1455, in <lambda>
    repoXML = property(fget=lambda self: self._getRepoXML(),
  File "/usr/lib/python2.6/site-packages/yum/yumRepo.py", line 1451, in _getRepoXML
    raise Errors.RepoError, msg
yum.Errors.RepoError: Cannot retrieve repository metadata (repomd.xml) for repository: omd. Please verify its path and try again
Debug: Executing '/usr/bin/python /usr/lib/ruby/site_ruby/1.8/puppet/provider/package/yumhelper.py'
Error: Could not get latest version: Execution of '/usr/bin/python /usr/lib/ruby/site_ruby/1.8/puppet/provider/package/yumhelper.py' returned 1: Loaded plugins: fastestmirror
Loading mirror speeds from cached hostfile
 * epel: mirror.vutbr.cz
Traceback (most recent call last):
  File "/usr/lib/ruby/site_ruby/1.8/puppet/provider/package/yumhelper.py", line 145, in <module>
    ypl = pkg_lists(my)
  File "/usr/lib/ruby/site_ruby/1.8/puppet/provider/package/yumhelper.py", line 58, in pkg_lists
    my.doTsSetup()
  File "/usr/lib/python2.6/site-packages/yum/depsolve.py", line 84, in doTsSetup
    return self._getTs()
  File "/usr/lib/python2.6/site-packages/yum/depsolve.py", line 99, in _getTs
    self._getTsInfo(remove_only)
  File "/usr/lib/python2.6/site-packages/yum/depsolve.py", line 110, in _getTsInfo
    pkgSack = self.pkgSack
  File "/usr/lib/python2.6/site-packages/yum/__init__.py", line 887, in <lambda>
    pkgSack = property(fget=lambda self: self._getSacks(),
  File "/usr/lib/python2.6/site-packages/yum/__init__.py", line 669, in _getSacks
    self.repos.populateSack(which=repos)
  File "/usr/lib/python2.6/site-packages/yum/repos.py", line 308, in populateSack
    sack.populate(repo, mdtype, callback, cacheonly)
  File "/usr/lib/python2.6/site-packages/yum/yumRepo.py", line 165, in populate
    if self._check_db_version(repo, mydbtype):
  File "/usr/lib/python2.6/site-packages/yum/yumRepo.py", line 223, in _check_db_version
    return repo._check_db_version(mdtype)
  File "/usr/lib/python2.6/site-packages/yum/yumRepo.py", line 1256, in _check_db_version
    repoXML = self.repoXML
  File "/usr/lib/python2.6/site-packages/yum/yumRepo.py", line 1455, in <lambda>
    repoXML = property(fget=lambda self: self._getRepoXML(),
  File "/usr/lib/python2.6/site-packages/yum/yumRepo.py", line 1451, in _getRepoXML
    raise Errors.RepoError, msg
yum.Errors.RepoError: Cannot retrieve repository metadata (repomd.xml) for repository: omd. Please verify its path and try again
Error: /Stage[main]/Rsyslog::Install/Package[rsyslog]/ensure: change from 5.8.10-8.el6 to latest failed: Could not get latest version: Execution of '/usr/bin/python /usr/lib/ruby/site_ruby/1.8/puppet/provider/package/yumhelper.py' returned 1: Loaded plugins: fastestmirror
Loading mirror speeds from cached hostfile
 * epel: mirror.vutbr.cz
Traceback (most recent call last):
  File "/usr/lib/ruby/site_ruby/1.8/puppet/provider/package/yumhelper.py", line 145, in <module>
    ypl = pkg_lists(my)
  File "/usr/lib/ruby/site_ruby/1.8/puppet/provider/package/yumhelper.py", line 58, in pkg_lists
    my.doTsSetup()
  File "/usr/lib/python2.6/site-packages/yum/depsolve.py", line 84, in doTsSetup
    return self._getTs()
  File "/usr/lib/python2.6/site-packages/yum/depsolve.py", line 99, in _getTs
    self._getTsInfo(remove_only)
  File "/usr/lib/python2.6/site-packages/yum/depsolve.py", line 110, in _getTsInfo
    pkgSack = self.pkgSack
  File "/usr/lib/python2.6/site-packages/yum/__init__.py", line 887, in <lambda>
    pkgSack = property(fget=lambda self: self._getSacks(),
  File "/usr/lib/python2.6/site-packages/yum/__init__.py", line 669, in _getSacks
    self.repos.populateSack(which=repos)
  File "/usr/lib/python2.6/site-packages/yum/repos.py", line 308, in populateSack
    sack.populate(repo, mdtype, callback, cacheonly)
  File "/usr/lib/python2.6/site-packages/yum/yumRepo.py", line 165, in populate
    if self._check_db_version(repo, mydbtype):
  File "/usr/lib/python2.6/site-packages/yum/yumRepo.py", line 223, in _check_db_version
    return repo._check_db_version(mdtype)
  File "/usr/lib/python2.6/site-packages/yum/yumRepo.py", line 1256, in _check_db_version
    repoXML = self.repoXML
  File "/usr/lib/python2.6/site-packages/yum/yumRepo.py", line 1455, in <lambda>
    repoXML = property(fget=lambda self: self._getRepoXML(),
  File "/usr/lib/python2.6/site-packages/yum/yumRepo.py", line 1451, in _getRepoXML
    raise Errors.RepoError, msg
yum.Errors.RepoError: Cannot retrieve repository metadata (repomd.xml) for repository: omd. Please verify its path and try again
Notice: /Stage[main]/Rsyslog::Config/File[/etc/sysconfig/rsyslog]: Dependency Package[rsyslog] has failures: true
Notice: /Stage[main]/Rsyslog::Config/File[/etc/sysconfig/rsyslog]: Dependency Package[rsyslog-relp] has failures: true
Warning: /Stage[main]/Rsyslog::Config/File[/etc/sysconfig/rsyslog]: Skipping because of failed dependencies
Notice: /Stage[main]/Rsyslog::Config/File[/etc/rsyslog.conf]: Dependency Package[rsyslog] has failures: true
Notice: /Stage[main]/Rsyslog::Config/File[/etc/rsyslog.conf]: Dependency Package[rsyslog-relp] has failures: true
Warning: /Stage[main]/Rsyslog::Config/File[/etc/rsyslog.conf]: Skipping because of failed dependencies
Notice: /Stage[main]/Rsyslog::Config/File[/etc/rsyslog.d/]: Dependency Package[rsyslog] has failures: true
Notice: /Stage[main]/Rsyslog::Config/File[/etc/rsyslog.d/]: Dependency Package[rsyslog-relp] has failures: true
Warning: /Stage[main]/Rsyslog::Config/File[/etc/rsyslog.d/]: Skipping because of failed dependencies
Debug: Executing '/usr/bin/python /usr/lib/ruby/site_ruby/1.8/puppet/provider/package/yumhelper.py'
Error: Could not get latest version: Execution of '/usr/bin/python /usr/lib/ruby/site_ruby/1.8/puppet/provider/package/yumhelper.py' returned 1: Loaded plugins: fastestmirror
Loading mirror speeds from cached hostfile
 * epel: mirror.vutbr.cz
Traceback (most recent call last):
  File "/usr/lib/ruby/site_ruby/1.8/puppet/provider/package/yumhelper.py", line 145, in <module>
    ypl = pkg_lists(my)
  File "/usr/lib/ruby/site_ruby/1.8/puppet/provider/package/yumhelper.py", line 58, in pkg_lists
    my.doTsSetup()
  File "/usr/lib/python2.6/site-packages/yum/depsolve.py", line 84, in doTsSetup
    return self._getTs()
  File "/usr/lib/python2.6/site-packages/yum/depsolve.py", line 99, in _getTs
    self._getTsInfo(remove_only)
  File "/usr/lib/python2.6/site-packages/yum/depsolve.py", line 110, in _getTsInfo
    pkgSack = self.pkgSack
  File "/usr/lib/python2.6/site-packages/yum/__init__.py", line 887, in <lambda>
    pkgSack = property(fget=lambda self: self._getSacks(),
  File "/usr/lib/python2.6/site-packages/yum/__init__.py", line 669, in _getSacks
    self.repos.populateSack(which=repos)
  File "/usr/lib/python2.6/site-packages/yum/repos.py", line 308, in populateSack
    sack.populate(repo, mdtype, callback, cacheonly)
  File "/usr/lib/python2.6/site-packages/yum/yumRepo.py", line 165, in populate
    if self._check_db_version(repo, mydbtype):
  File "/usr/lib/python2.6/site-packages/yum/yumRepo.py", line 223, in _check_db_version
    return repo._check_db_version(mdtype)
  File "/usr/lib/python2.6/site-packages/yum/yumRepo.py", line 1256, in _check_db_version
    repoXML = self.repoXML
  File "/usr/lib/python2.6/site-packages/yum/yumRepo.py", line 1455, in <lambda>
    repoXML = property(fget=lambda self: self._getRepoXML(),
  File "/usr/lib/python2.6/site-packages/yum/yumRepo.py", line 1451, in _getRepoXML
    raise Errors.RepoError, msg
yum.Errors.RepoError: Cannot retrieve repository metadata (repomd.xml) for repository: omd. Please verify its path and try again
Error: /Stage[main]/Autofs/Package[autofs]/ensure: change from 5.0.5-89.el6_5.2 to latest failed: Could not get latest version: Execution of '/usr/bin/python /usr/lib/ruby/site_ruby/1.8/puppet/provider/package/yumhelper.py' returned 1: Loaded plugins: fastestmirror
Loading mirror speeds from cached hostfile
 * epel: mirror.vutbr.cz
Traceback (most recent call last):
  File "/usr/lib/ruby/site_ruby/1.8/puppet/provider/package/yumhelper.py", line 145, in <module>
    ypl = pkg_lists(my)
  File "/usr/lib/ruby/site_ruby/1.8/puppet/provider/package/yumhelper.py", line 58, in pkg_lists
    my.doTsSetup()
  File "/usr/lib/python2.6/site-packages/yum/depsolve.py", line 84, in doTsSetup
    return self._getTs()
  File "/usr/lib/python2.6/site-packages/yum/depsolve.py", line 99, in _getTs
    self._getTsInfo(remove_only)
  File "/usr/lib/python2.6/site-packages/yum/depsolve.py", line 110, in _getTsInfo
    pkgSack = self.pkgSack
  File "/usr/lib/python2.6/site-packages/yum/__init__.py", line 887, in <lambda>
    pkgSack = property(fget=lambda self: self._getSacks(),
  File "/usr/lib/python2.6/site-packages/yum/__init__.py", line 669, in _getSacks
    self.repos.populateSack(which=repos)
  File "/usr/lib/python2.6/site-packages/yum/repos.py", line 308, in populateSack
    sack.populate(repo, mdtype, callback, cacheonly)
  File "/usr/lib/python2.6/site-packages/yum/yumRepo.py", line 165, in populate
    if self._check_db_version(repo, mydbtype):
  File "/usr/lib/python2.6/site-packages/yum/yumRepo.py", line 223, in _check_db_version
    return repo._check_db_version(mdtype)
  File "/usr/lib/python2.6/site-packages/yum/yumRepo.py", line 1256, in _check_db_version
    repoXML = self.repoXML
  File "/usr/lib/python2.6/site-packages/yum/yumRepo.py", line 1455, in <lambda>
    repoXML = property(fget=lambda self: self._getRepoXML(),
  File "/usr/lib/python2.6/site-packages/yum/yumRepo.py", line 1451, in _getRepoXML
    raise Errors.RepoError, msg
yum.Errors.RepoError: Cannot retrieve repository metadata (repomd.xml) for repository: omd. Please verify its path and try again

[....]
```

verified repo issue:

``` bash
$ URLGRABBER_DEBUG=1 yum check-update

[...]

2014-06-17 14:56:55,646 attempt 1/10: https://labs.consol.de/repo/stable/rhel/x86_64/repodata/repomd.xml
INFO:urlgrabber:attempt 1/10: https://labs.consol.de/repo/stable/rhel/x86_64/repodata/repomd.xml
2014-06-17 14:56:55,647 opening local file "/var/cache/yum/x86_64/6/omd/repomdyBe6uItmp.xml" with mode wb
INFO:urlgrabber:opening local file "/var/cache/yum/x86_64/6/omd/repomdyBe6uItmp.xml" with mode wb
* About to connect() to labs.consol.de port 443 (#0)
*   Trying 94.185.89.33... * connected
* Connected to labs.consol.de (94.185.89.33) port 443 (#0)
* Initializing NSS with certpath: sql:/etc/pki/nssdb
*   CAfile: /etc/pki/tls/certs/ca-bundle.crt
  CApath: none
* SSL connection using TLS_DHE_RSA_WITH_AES_256_CBC_SHA
* Server certificate:
*   subject: CN=*.consol.de,OU=Domain Control Validated - RapidSSL(R),OU=See www.rapidssl.com/resources/cps (c)14,OU=GT91455568,serialNumber=ppNpCTwF4NV224IZ6d/hmwlYxXYM4pU0
*   start date: Apr 07 15:36:55 2014 GMT
*   expire date: Jun 27 21:17:58 2018 GMT
*   common name: *.consol.de
*   issuer: CN=RapidSSL CA,O="GeoTrust, Inc.",C=US
> GET /repo/stable/rhel/x86_64/repodata/repomd.xml HTTP/1.1
User-Agent: urlgrabber/3.9.1 yum/3.2.29
Host: labs.consol.de
Accept: */*

* The requested URL returned error: 404 Not Found
* Closing connection #0
2014-06-17 14:56:55,788 exception: [Errno 14] PYCURL ERROR 22 - "The requested URL returned error: 404 Not Found"
INFO:urlgrabber:exception: [Errno 14] PYCURL ERROR 22 - "The requested URL returned error: 404 Not Found"
2014-06-17 14:56:55,788 calling callback: (<bound method YumBaseCli.failureReport of <cli.YumBaseCli object at 0x1819090>>, (), {})
INFO:urlgrabber:calling callback: (<bound method YumBaseCli.failureReport of <cli.YumBaseCli object at 0x1819090>>, (), {})
https://labs.consol.de/repo/stable/rhel/x86_64/repodata/repomd.xml: [Errno 14] PYCURL ERROR 22 - "The requested URL returned error: 404 Not Found"
Trying other mirror.
2014-06-17 14:56:55,789 MIRROR: failed
INFO:urlgrabber:MIRROR: failed
2014-06-17 14:56:55,789 GR   mirrors: [] 0
INFO:urlgrabber:GR   mirrors: [] 0
2014-06-17 14:56:55,789 MAIN mirrors: [https://labs.consol.de/repo/stable/rhel/x86_64/] 0
INFO:urlgrabber:MAIN mirrors: [https://labs.consol.de/repo/stable/rhel/x86_64/] 0
Error: Cannot retrieve repository metadata (repomd.xml) for repository: omd. Please verify its path and try again
```
