### PR TITLE
fix "no tty" issue with sudo by using su

### DIFF
--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -36,7 +36,7 @@ define omd::site(
   #refreshonly check_mk reload
   exec { "checkmk_refresh_${name}":
     path => ['/usr/bin','/usr/sbin','/bin','/sbin',],
-    command     => "sudo -i -u ${name} /opt/omd/sites/${name}/bin/cmk -O",
+    command     => "su -c '/opt/omd/sites/${name}/bin/cmk -O' -s /bin/sh ${name}",
     refreshonly => true,
     require => Exec["omd create site ${name}"],
     tag => 'check_mk_refresh_site', #used to be notified of a global check_mk config change, requiring a reload


### PR DESCRIPTION
the use of `sudo` creates an issue with default sudo installations on CentOS 6: sudo is expecting a tty, which puppet might not be able to provide. `sudo` might also not be installed by default on minimal-install systems - this patch takes care of both discussed issues.

for reference:

``` bash

Debug: Exec[checkmk_refresh_infra](provider=posix): Executing 'sudo -i -u infra /opt/omd/sites/infra/bin/cmk -O'
Debug: Executing 'sudo -i -u infra /opt/omd/sites/infra/bin/cmk -O'
Notice: /Stage[main]/Monitoring/Omd::Site[infra]/Exec[checkmk_refresh_infra]/returns: sudo: sorry, you must have a tty to run sudo
Error: /Stage[main]/Monitoring/Omd::Site[infra]/Exec[checkmk_refresh_infra]: Failed to call refresh: sudo -i -u infra /opt/omd/sites/infra/bin/cmk -O returned 1 instead of one of [0]
Error: /Stage[main]/Monitoring/Omd::Site[infra]/Exec[checkmk_refresh_infra]: sudo -i -u infra /opt/omd/sites/infra/bin/cmk -O returned 1 instead of one of [0]
```
