### PR TITLE
fix sudo bug in check_mk::addhost

### DIFF
--- a/manifests/check_mk/addhost.pp
+++ b/manifests/check_mk/addhost.pp
@@ -53,7 +53,7 @@ define omd::check_mk::addhost(
       }  
     } else {
       exec { "checkmk_inventory_${hname}_${site}":
-        command     => "sudo -i -u ${site} /opt/omd/sites/${site}/bin/cmk -I $hname",
+        command     => "su -l -c '/opt/omd/sites/${site}/bin/cmk -I $hname' -s /bin/sh ${site}",
         path => ['/usr/bin','/usr/sbin','/bin','/sbin',],
         notify      => Exec["checkmk_refresh_${site}"],
         refreshonly => true,


### PR DESCRIPTION
same issue as https://github.com/GRIF-IRFU/puppet-omd/pull/4 in `check_mk::addhost`. this patch fixes the reported issue.

``` puppet
...
Debug: Executing 'sudo -i -u infra /opt/omd/sites/infra/bin/cmk -I HOST'
Notice: /Stage[main]/Monitoring/Omd::Check_mk::Addhost[HOST]/Exec[checkmk_inventory_HOST_infra]/returns: sudo: sorry, you must have a tty to run sudo
Error: /Stage[main]/Monitoring/Omd::Check_mk::Addhost[HOST]/Exec[checkmk_inventory_HOST_infra]: Failed to call refresh: sudo -i -u infra /opt/omd/sites/infra/bin/cmk -I HOST returned 1 instead of one of [0]
Error: /Stage[main]/Monitoring/Omd::Check_mk::Addhost[HOST]/Exec[checkmk_inventory_HOST_infra]: sudo -i -u infra /opt/omd/sites/infra/bin/cmk -I HOST returned 1 instead of one of [0]
...
```

(the actual hostname has been replaced with `HOST`)
