### PR TITLE
Update debian.pp

### DIFF
--- a/manifests/repos/debian.pp
+++ b/manifests/repos/debian.pp
@@ -6,7 +6,7 @@ include '::apt'
     location => 'http://labs.consol.de/repo/stable/debian',
     release => "$::lsbdistcodename",
     repos => 'main',
-    key => 'F8C1CA08A57B9ED7',
+    key => 'F2F97737B59ACCC92C23F8C7F8C1CA08A57B9ED7',
     key_server => 'keys.gnupg.net',
     before => Package['omd'],
     include_src       => false


### PR DESCRIPTION
Apt_key module dependency warns :

 Warning: /Apt_key[Add key: F8C1CA08A57B9ED7 from Apt::Source omd]: The id should be a full fingerprint (40 characters), see README.