### PR TITLE
Support for rhel 7

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,8 +12,11 @@ class omd(
   $omd_version='1.20', #or omd-1.11.20140328
   $omd_release=latest,
 ) {
-  
-  
+
+  if( $facts['os']['release']['major'] == '7' ) {
+    require epel
+  }
+
   if($with_repo) {
     case $::osfamily {
       debian : { include omd::repos::debian }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,7 +13,7 @@ class omd(
   $omd_release=latest,
 ) {
 
-  if( $::osfamily == 'redhat' and $facts['os']['release']['major'] == '7' ) {
+  if( $::osfamily == 'redhat' and $::operatingsystemmajrelease >= '6' ) {
     require epel
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,10 +13,6 @@ class omd(
   $omd_release=latest,
 ) {
 
-  if( $::osfamily == 'redhat' and $::operatingsystemmajrelease >= '6' ) {
-    require epel
-  }
-
   if($with_repo) {
     case $::osfamily {
       debian : { include omd::repos::debian }
@@ -27,7 +23,12 @@ class omd(
 
   case $::osfamily {
     debian : { $omd_service = "omd-$omd_version" }
-    redhat : { $omd_service = "omd" }
+    redhat : { 
+      if(0+$::operatingsystemmajrelease >= 6){
+        require epel
+      }
+      $omd_service = "omd"
+    }
     default : { fail("unsupported os family : $::osfamily")}
   }
   

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,7 +13,7 @@ class omd(
   $omd_release=latest,
 ) {
 
-  if( $facts['os']['release']['major'] == '7' ) {
+  if( $::osfamily == 'redhat' and $facts['os']['release']['major'] == '7' ) {
     require epel
   }
 

--- a/manifests/repos/redhat.pp
+++ b/manifests/repos/redhat.pp
@@ -16,11 +16,4 @@ class omd::repos::redhat {
     gpgcheck => 1,
     gpgkey => 'https://labs.consol.de/repo/testing/RPM-GPG-KEY',
   }  
-
-  # The epel release is needed to install some dependencies
-  if( $facts['os']['release']['major'] == '7' ) {
-    package { 'epel-release':
-      ensure => present,
-    }
-  }
 }

--- a/manifests/repos/redhat.pp
+++ b/manifests/repos/redhat.pp
@@ -16,4 +16,11 @@ class omd::repos::redhat {
     gpgcheck => 1,
     gpgkey => 'https://labs.consol.de/repo/testing/RPM-GPG-KEY',
   }  
+
+  # The epel release is needed to install some dependencies
+  if( $facts['os']['release']['major'] == '7' ) {
+    package { 'epel-release':
+      ensure => present,
+    }
+  }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
   "operatingsystem_support": [
     {
     "operatingsystem":"RedHat",
-    "operatingsystemrelease":[ "6.0" ]
+    "operatingsystemrelease":[ "6.0", "7.0"]
     }
   ],
   "source": "https://github.com/GRIF-IRFU/puppet-omd",

--- a/metadata.json
+++ b/metadata.json
@@ -5,6 +5,7 @@
     {"name":"puppetlabs/concat","version_requirement":">= 1.2.0"},
     {"name":"puppetlabs/xinetd","version_requirement":">= 1.5.0"},
     {"name":"puppetlabs/apt","version_requirement":">= 1.8.0"}
+    {"name":"stahnma/epel","version_requirement":">= 1.2.0"}
   ],
   "license": "CeCILL-C_V1",
   "name": "fschaer-omd",


### PR DESCRIPTION
On systems with rhel 7, the epel release is mandatory to install some required packages.
I added an if statement which installs the epel from the package repository if the OS version is 7.

Please let me know if you need further informations.