### PR TITLE
Rhel7.2 bugfix

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,8 +12,11 @@ class omd(
   $omd_version='1.20', #or omd-1.11.20140328
   $omd_release=latest,
 ) {
-  
-  
+
+  if( $facts['os']['release']['major'] == '7' ) {
+    require epel
+  }
+
   if($with_repo) {
     case $::osfamily {
       debian : { include omd::repos::debian }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,7 +13,7 @@ class omd(
   $omd_release=latest,
 ) {
 
-  if( $::osfamily == 'redhat' and $facts['os']['release']['major'] == '7' ) {
+  if( $::osfamily == 'redhat' and $::operatingsystemmajrelease >= '6' ) {
     require epel
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,10 +13,6 @@ class omd(
   $omd_release=latest,
 ) {
 
-  if( $::osfamily == 'redhat' and $::operatingsystemmajrelease >= '6' ) {
-    require epel
-  }
-
   if($with_repo) {
     case $::osfamily {
       debian : { include omd::repos::debian }
@@ -27,7 +23,12 @@ class omd(
 
   case $::osfamily {
     debian : { $omd_service = "omd-$omd_version" }
-    redhat : { $omd_service = "omd" }
+    redhat : { 
+      if(0+$::operatingsystemmajrelease >= 6){
+        require epel
+      }
+      $omd_service = "omd"
+    }
     default : { fail("unsupported os family : $::osfamily")}
   }
   

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,7 +13,7 @@ class omd(
   $omd_release=latest,
 ) {
 
-  if( $facts['os']['release']['major'] == '7' ) {
+  if( $::osfamily == 'redhat' and $facts['os']['release']['major'] == '7' ) {
     require epel
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,6 +11,7 @@ class omd(
   $with_repo=true,
   $omd_version='1.20', #or omd-1.11.20140328
   $omd_release=latest,
+  $fix_v130bug=false, # fixes a bug, which gives an internal error 500
 ) {
 
   if($with_repo) {
@@ -23,11 +24,28 @@ class omd(
 
   case $::osfamily {
     debian : { $omd_service = "omd-$omd_version" }
-    redhat : { 
+    redhat : {
       if(0+$::operatingsystemmajrelease >= 6){
         require epel
       }
       $omd_service = "omd"
+
+      # This is a bugfix for wrong python libraries in Centos 7.2 with omd 1.30
+      if( $fix_v130bug ) {
+        notify { 'workaround information':
+          message => "The hashlib symlinks are being created as Workaround to a bug in omd Version 1.30",
+        }
+        file { '/opt/omd/versions/1.30/lib/python/hashlib.py':
+          ensure => link,
+          target => "/usr/lib64/python2.7/hashlib.py",
+          require => Package['omd'],
+        }
+        file { '/opt/omd/versions/1.30/lib/python/hashlib.pyc':
+          ensure => link,
+          target => "/usr/lib64/python2.7/hashlib.pyc",
+          require => Package['omd'],
+        }
+      }
     }
     default : { fail("unsupported os family : $::osfamily")}
   }
@@ -35,5 +53,5 @@ class omd(
   package {"omd": name => "omd-$omd_version", ensure => $omd_release}
   ->
   service {'omd': name => "$omd_service", enable => true, ensure => running}
-  
+
 }

--- a/manifests/repos/redhat.pp
+++ b/manifests/repos/redhat.pp
@@ -16,11 +16,4 @@ class omd::repos::redhat {
     gpgcheck => 1,
     gpgkey => 'https://labs.consol.de/repo/testing/RPM-GPG-KEY',
   }  
-
-  # The epel release is needed to install some dependencies
-  if( $facts['os']['release']['major'] == '7' ) {
-    package { 'epel-release':
-      ensure => present,
-    }
-  }
 }

--- a/manifests/repos/redhat.pp
+++ b/manifests/repos/redhat.pp
@@ -16,4 +16,11 @@ class omd::repos::redhat {
     gpgcheck => 1,
     gpgkey => 'https://labs.consol.de/repo/testing/RPM-GPG-KEY',
   }  
+
+  # The epel release is needed to install some dependencies
+  if( $facts['os']['release']['major'] == '7' ) {
+    package { 'epel-release':
+      ensure => present,
+    }
+  }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
   "operatingsystem_support": [
     {
     "operatingsystem":"RedHat",
-    "operatingsystemrelease":[ "6.0" ]
+    "operatingsystemrelease":[ "6.0", "7.0"]
     }
   ],
   "source": "https://github.com/GRIF-IRFU/puppet-omd",

--- a/metadata.json
+++ b/metadata.json
@@ -15,7 +15,7 @@
   "operatingsystem_support": [
     {
     "operatingsystem":"RedHat",
-    "operatingsystemrelease":[ "6.0", "7.0"]
+    "operatingsystemrelease":[ "6.0", "7.0", "7.2"]
     }
   ],
   "source": "https://github.com/GRIF-IRFU/puppet-omd",

--- a/metadata.json
+++ b/metadata.json
@@ -5,6 +5,7 @@
     {"name":"puppetlabs/concat","version_requirement":">= 1.2.0"},
     {"name":"puppetlabs/xinetd","version_requirement":">= 1.5.0"},
     {"name":"puppetlabs/apt","version_requirement":">= 1.8.0"}
+    {"name":"stahnma/epel","version_requirement":">= 1.2.0"}
   ],
   "license": "CeCILL-C_V1",
   "name": "fschaer-omd",


### PR DESCRIPTION
Hi again!
On rhel 7.2 with omd 1.30 is a bug, which is described here: [https://monitoring-portal.org/index.php?thread/35120-solved-omd-internal-server-error-centos-7-2/](url)

The same thread describes the solution to the bug; copying two hashlib files from the python 2.7 installation to omd.
Since this is a very rare situation, I created a new variable $fix_130bug, which is false by default. Once set to true and on rhel, the two wrong hashlib files are being replaced by softlinks pointing to the files in the python installation (I found no useful resource definition for puppet to copy the files and delivering them with the module is in my opinion a bit wasteful for this rare situation).