### PR TITLE
Var type

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ check parameters...
     
     #don't use the deprecated network check
     omd::check_mk::var::set {linux_nic_check: site=>'test', content=>'"lnx_if"'}
+
+    #Adding a seconf check_parameter with descriptive resource name (the concat order can be given, but doesn't have to):
+    omd::check_mk::var::append { 'boot_partition': site=>'test', type=>'check_parameters', content=>'[( (95,98,1)  ,   ALL_HOSTS, [ "fs_/boot$",])]'}
     
 Performance data...
 

--- a/manifests/check_mk/configfile.pp
+++ b/manifests/check_mk/configfile.pp
@@ -1,6 +1,6 @@
 /**
  * Ensures a config file is present, and allows duplicate resource declaration
- * 
+ *
  * Please ommit the '.mk' from the filename
  */
  define omd::check_mk::configfile(
@@ -8,13 +8,13 @@
    $filename=$name, #required in case there are 2 omd sites
    $component='check_mk', #this allows to define config files for other components. Currently, only multisite|check_mk is allowed
  ) {
-  
+
   # multisite or check_mk ?
   $path = $component ? {
     'multisite' => 'multisite.d',
     default => 'conf.d/puppet'
   }
-  
+
   #prepare custom user-specified check_mk configuration files (prepare the concat)
   # the user can then add any check_mk var user omd::check_mk::addvar
   concat{"check_mk_puppetvars_${site}_${filename}_${component}":
@@ -26,7 +26,7 @@
    }
    ->
    Exec <| tag == "checkmk_inventory" |>
-   
+
    concat::fragment{"check_mk_puppetvars_${site}_${filename}_${component}_header":
       target => "check_mk_puppetvars_${site}_${filename}_${component}",
       content => "#\n# puppet-managed file. Do not edit\n#\n",
@@ -34,5 +34,5 @@
    }
    ->
    Exec <| tag == "checkmk_inventory" |>
-   
+
  }

--- a/manifests/check_mk/var/append.pp
+++ b/manifests/check_mk/var/append.pp
@@ -25,6 +25,7 @@
 define omd::check_mk::var::append(
   $site,
   $content,
+  $type=undef,
   $concat_order=20,
   $cfgfile=undef,
   $component='check_mk', #this allows to define config files for other components. Currently, only multisite|check_mk is allowed
@@ -76,9 +77,13 @@ define omd::check_mk::var::append(
     default => $array_name[1]
   }
 
-  $var_str=$subvar ? {
-    undef => "${array_name[0]} +=",
-    default => "${array_name[0]}['${subvar}'] +=",
+  if $type {
+    $var_str = "${type} +="
+  } else {
+    $var_str=$subvar ? {
+      undef => "${array_name[0]} +=",
+      default => "${array_name[0]}['${subvar}'] +=",
+    }
   }
 
 

--- a/manifests/check_mk/var/set.pp
+++ b/manifests/check_mk/var/set.pp
@@ -1,24 +1,24 @@
 /**
  * This allows the user to add arbitrary variables to the check_mk configuration.
  * This will use a concat file
- * This will only set variables, and eventually set a subvariable of this variable. 
- * 
- * 
+ * This will only set variables, and eventually set a subvariable of this variable.
+ *
+ *
  * This resource will add a configuration file to an OMD site, and thus will require this site to be setup before it can be applied.
- * 
+ *
  * Resource name is the variable name
  * If the resource name contains a '#', then the remainder of the resource name is assumed to be a subvar to which the resource contents must be affected
- * 
+ *
  * Argument description :
  * - site : required, this is the site where the variable will be setup
  * - content  : this is the variable content. Required. Please don't specify the openning and closing python braces.
  * - cfgfile  : this is the config file *name* to use. By default, use the global config file. These files will be located under conf.d/puppet/ . Any non standard char will be stripped.
- * Example usage: 
- * 
- * 
+ * Example usage:
+ *
+ *
  * omd::check_mk::set {: site=>'test', var=> 'ignored_checktypes', operator=> '+=', content=>'"if64" ,"nfsmounts"'}
- * 
- * 
+ *
+ *
  */
 define omd::check_mk::var::set(
   $site,
@@ -28,36 +28,36 @@ define omd::check_mk::var::set(
   $cfgfile=undef,
   $component='check_mk', #this allows to define config files for other components. Currently, only multisite|check_mk is allowed
 ) {
-  
+
   $config=$cfgfile ? {
     undef => 'global',
     default => regsubst($cfgfile,'[^a-zA-Z0-9.-_]','','G')
   }
-  
+
   # multisite or check_mk ?
   $comp = $component ? {
     'multisite' => 'multisite',
     default => 'check_mk'
   }
-  
+
   #ensure the config file exists
   ensure_resource('omd::check_mk::configfile', "${config}_${site}_${comp}" , {site=>$site, filename=>$config, component => $comp})
-  
+
   #find if there is a subvar :
   # did not find how to split a string and force at most N elements to be returned, so : replace a # with something improbable to be user-defined, then split on that
   $split_tag='#___#__#_#'
   $array_name=split(regsubst($variable,'#',$split_tag),$split_tag)
-  
+
   $subvar= $array_name[1] ? {
     undef => undef,
     default => $array_name[1]
   }
-  
+
   $var_str=$subvar ? {
     undef => "${array_name[0]} =",
     default => "${array_name[0]}['${subvar}'] =",
   }
-  
+
   #$content_hash=md5($content) #maybe this can proove to heavy on puppet master...
 
   concat::fragment{"check_mk_puppetvars_${site}_${array_name[0]}_${subvar}":
@@ -68,5 +68,5 @@ define omd::check_mk::var::set(
   }
   ->
   Exec <| tag == "checkmk_inventory" |>
-  
+
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -33,7 +33,7 @@ class omd(
     'RedHat': {
       $omd_service = 'omd'
       $dbi_pkg = 'libdbi'
-      $svc_provider='init'
+      $svc_provider='redhat'
       if( 0+$::operatingsystemmajrelease >= 6 ) {
         require epel
       }


### PR DESCRIPTION
Hi
We want to define our check_mk rules in different files, seperated by application, but the `omd::check_mk::var::append` resources are a problem, since their name is used as variable-name in the config file. This makes it hard for us to not get a duplicated resource when defining them in different files.

I have seen that the class splits the name and uses it to determine the concat order.
with this commit, the concatenation part is still done, if a `|number` is given, it will be applied to the order, but variable name can also be given like this:
```
type => 'ignored_services',
```